### PR TITLE
Lazy namespace

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,9 @@
 CHANGES
 
+0.4.0
+
+- Added lazy functions in com.climate.claypoole.lazy
+
 0.3.3
 
 - Fixed memory leak / overeager pushing of tasks into the queue

--- a/README.md
+++ b/README.md
@@ -234,32 +234,57 @@ not compute work until forced by something like `(doall)`, just like core `map`
 and `pmap`.
 
 Like core `pmap`, they will only run the outputs you realize, plus a few more
-(a buffer). The buffer is used to help keep the threadpool busy. Each parallel
-function also comes with a -buffer variant that allows you to specify the
-buffer size. The non -buffer forms use the threadpool size as their buffer
-size.
+(a buffer). The buffer is used to help keep the threadpool busy. Unlike core
+`pmap`, the buffer size is not fixed at `ncpus + 2`; instead, it defaults to
+the size of the threadpool to keep the pool full. Each parallel function also
+comes with a -buffer variant that has an extra argument, allowing you to
+specify the buffer size.
 
 For instance, these will both cause 10 items to be realized:
 
 ```clojure
+(require '[com.climate.claypoole :as cp])
+(require '[com.climate.claypoole.lazy :as lazy])
 (cp/with-shutdown! [pool 2]
   (doall (take 8 (lazy/pmap pool inc (range))))
   (doall (take 4 (lazy/pmap-buffer pool 6 inc (range)))))
 ```
 
+### Lazy Advantages
+
+The lazy functions work well with sequences too large to fit in memory.
+Furthermore, the lazy functions work well with chained maps that operate at
+different speeds over large amounts of data. If an eager map that runs quickly
+feeds into an eager map that runs slowly, the buffer between them will tend to
+grow, possibly running the system out of memory. Lazy functions will avoid this
+by only performing work as needed.
+
+As a rule of thumb, if you are working with data too large to fit into memory,
+you probably want a lazy operation.
+
+### Lazy Disadvantages
+
 The disadvantage of the lazy functions is that they may not keep the threadpool
-as busy. For instance, this pmap will take 6 milliseconds to run:
+fully busy. For instance, this pmap will take 6 seconds to run:
 
 ```clojure
-(lazy/pmap 2 #(Thread/sleep %) [4 3 2 1])
+(doall (lazy/pmap 2 #(Thread/sleep (* % 1000)) [4 3 2 1]))
 ```
 
 That's because it will not realize the 2 task until the 4 task is complete, so
-one thread in the pool will sit idle for 1 millisecond.
+one thread in the pool will sit idle for 1 second. On the other hand, an eager
+function would only take 5 seconds, since the two threads would be assigned
+tasks as follows:
 
-To use the threadpool most efficiently with these lazy functions, prefer the
-unordered versions (e.g. `upmap`), since the ordered ones may starve the
-threadpool of work.
+4: Thread 0
+3: Thread 1
+2: Thread 1
+1: Thread 0
+
+Note also that an unordered map (`upmap`) would also take 5 seconds here, since
+as soon as 3 is complete, it would be returned and the next item would be
+forced. In general, to use the threadpool most efficiently with these lazy
+functions, prefer the unordered versions.
 
 ## How can I prioritize my tasks?
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,14 @@ function also comes with a -buffer variant that allows you to specify the
 buffer size. The non -buffer forms use the threadpool size as their buffer
 size.
 
+For instance, these will both cause 10 items to be realized:
+
+```clojure
+(cp/with-shutdown! [pool 2]
+  (doall (take 8 (lazy/pmap pool inc (range))))
+  (doall (take 4 (lazy/pmap-buffer pool 6 inc (range)))))
+```
+
 The disadvantage of the lazy functions is that they may not keep the threadpool
 as busy. For instance, this pmap will take 6 milliseconds to run:
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ several ways:
   the amount of simultaneous work we're doing.
 * We would like it to be eagerly streaming rather than lazy, so we can start it
   going and expect it to work in the background without explicitly consuming
-  the results. *As of Claypoole 0.4.0, it provides lazy maps in
+  the results. *As of Claypoole 0.4.0, there are lazy maps in
   `com.climate.claypoole.lazy`. See the section [Lazy](#lazy) below.*
 * We would like to be able to do an unordered `pmap`, so that we can start
   handling the first response as fast as possible.
@@ -59,7 +59,7 @@ Note that these functions are eager! That's on purpose--we like to be able to
 start work going and know it'll get done. But if you try to `pmap` over
 `(range)`, you're going to have a bad time.
 
-*As of Claypoole 0.4.0, it provides lazy functions in
+*As of Claypoole 0.4.0, there are lazy functions in
 `com.climate.claypoole.lazy`. See the section [Lazy](#lazy) below.*
 
 ```clojure

--- a/src/clj/com/climate/claypoole.clj
+++ b/src/clj/com/climate/claypoole.clj
@@ -218,7 +218,7 @@
              (when (threadpool? ~pool-sym)
                (shutdown! ~pool-sym))))))))
 
-(defn- serial?
+(defn serial?
   "Check if we should run this computation in serial."
   [pool]
   (or (not *parallel*) (= pool :serial)))

--- a/src/clj/com/climate/claypoole/impl.clj
+++ b/src/clj/com/climate/claypoole/impl.clj
@@ -251,7 +251,7 @@
   (defn queue-seq-add!
     "Add an item to a queue (and its lazy sequence)."
     [^LinkedBlockingQueue q x]
-    (.add q x))
+    (.put q x))
 
   (defn queue-seq-end!
     "End a lazy sequence reading from a queue."

--- a/src/clj/com/climate/claypoole/lazy.clj
+++ b/src/clj/com/climate/claypoole/lazy.clj
@@ -115,9 +115,6 @@
   [pool f & colls]
   (apply upmap-manual pool (impl/get-pool-size pool) f colls))
 
-;; TODO move the following definitions to a macro? But a macro-defining-macro
-;; is a bit ugly
-
 (defn pcalls
   "Like clojure.core.pcalls, except it takes a threadpool. For more detail on
   its parallelism and on its threadpool argument, see pmap."

--- a/src/clj/com/climate/claypoole/lazy.clj
+++ b/src/clj/com/climate/claypoole/lazy.clj
@@ -70,10 +70,10 @@
     (apply map f colls)
     (let [[shutdown? pool] (impl/->threadpool pool)]
       (->> colls
+           ;; make sure we're not chunking
+           (map impl/unchunk)
            ;; use map to take care of argument alignment
            (apply map vector)
-           ;; make sure we're not chunking
-           impl/unchunk
            ;; make futures
            (map (fn [a] (cp/future-call pool
                                         ;; Use with-meta for priority
@@ -122,10 +122,10 @@
                                                    (finally (.put result-q @p)))
                                              {:args a})))))]
       (->> colls
+           ;; make sure we're not chunking
+           (map impl/unchunk)
            ;; use map to take care of argument alignment
            (apply map vector)
-           ;; make sure we're not chunking
-           impl/unchunk
            ;; make futures
            (map run-one)
            ;; force buffer-size futures to start work in the pool

--- a/src/clj/com/climate/claypoole/lazy.clj
+++ b/src/clj/com/climate/claypoole/lazy.clj
@@ -75,7 +75,7 @@
                                 pool
                                 ;; Use with-meta for priority threadpools
                                 (with-meta #(try (apply f a)
-                                                 (finally (.add result-q @p)))
+                                                 (finally (.put result-q @p)))
                                            {:args a})))))]
     (->> colls
          ;; use map to take care of argument alignment

--- a/src/clj/com/climate/claypoole/lazy.clj
+++ b/src/clj/com/climate/claypoole/lazy.clj
@@ -50,7 +50,8 @@
   (lazy-seq
     (let [sprime (try
                    ;; force one element of s to make exceptions happen here
-                   (when (seq s) (cons (first s) (rest s)))
+                   (when-let [s (seq s)]
+                     (cons (first s) (rest s)))
                    (catch Throwable t
                      (f)
                      (throw t)))]

--- a/src/clj/com/climate/claypoole/lazy.clj
+++ b/src/clj/com/climate/claypoole/lazy.clj
@@ -1,0 +1,153 @@
+(ns com.climate.claypoole.lazy
+  (:refer-clojure :exclude [future future-call pcalls pmap pvalues])
+  (:require [com.climate.claypoole :as cp]
+            [com.climate.claypoole.impl :as impl])
+  (:import [java.util.concurrent LinkedBlockingQueue]))
+
+
+(defn- forceahead
+  "A sequence of s with the next buffer-size elements of it forced."
+  [buffer-size s]
+  (map (fn [x _] x)
+       s
+       (concat (drop buffer-size s) (repeat nil))))
+
+(defn- pool-closer
+  "Given a sequence, concat onto its end a lazy sequence that will shutdown a
+  pool when forced."
+  [shutdown? pool s]
+  (concat s
+          ;; Shutdown the pool if needed.
+          (lazy-seq
+            (do
+              (when shutdown? (cp/shutdown pool))
+              nil))))
+
+(defn pmap-manual
+  "A lazy pmap where the work happens in a threadpool, just like core pmap, but
+  using claypoole futures.
+
+  Unlike core pmap, it doesn't assume the buffer size is nprocessors + 2;
+  instead, you must specify how many tasks ahead will be run in the
+  background."
+  [pool buffer-size f & colls]
+  (let [[shutdown? pool] (impl/->threadpool pool)]
+    (->> colls
+         ;; use map to take care of argument alignment
+         (apply map vector)
+         ;; make sure we're not chunking
+         impl/unchunk
+         ;; make futures
+         (map (fn [a] (cp/future-call pool
+                                      ;; Use with-meta for priority
+                                      ;; threadpools
+                                      (with-meta #(apply f a)
+                                                 {:args a}))))
+         ;; force buffer-size futures to start work in the pool
+         (forceahead buffer-size)
+         ;; read the results from the futures
+         (map deref)
+         (pool-closer shutdown? pool))))
+
+(defn pmap
+  "A lazy pmap where the work happens in a threadpool, just like core pmap, but
+  using claypoole futures.
+
+  Unlike core pmap, it doesn't assume the buffer size is nprocessors + 2;
+  instead, it tries to fill the pool."
+  [pool f & colls]
+  (apply pmap-manual pool (impl/get-pool-size pool) f colls))
+
+(defn upmap-manual
+  "Like pmap-manual, but with results returned in the order they completed.
+
+  Note that unlike core pmap, it doesn't assume the buffer size is nprocessors
+  + 2; instead, you must specify how many tasks ahead will be run in the
+  background."
+  [pool buffer-size f & colls]
+  (let [[shutdown? pool] (impl/->threadpool pool)
+        result-q (LinkedBlockingQueue. (int buffer-size))
+        run-one (fn [a]
+                  (let [p (promise)]
+                    @(deliver p
+                              (cp/future-call
+                                pool
+                                ;; Use with-meta for priority threadpools
+                                (with-meta #(try (apply f a)
+                                                 (finally (.add result-q @p)))
+                                           {:args a})))))]
+    (->> colls
+         ;; use map to take care of argument alignment
+         (apply map vector)
+         ;; make sure we're not chunking
+         impl/unchunk
+         ;; make futures
+         (map run-one)
+         ;; force buffer-size futures to start work in the pool
+         (forceahead buffer-size)
+         ;; read the results from the futures in the queue
+         (map (fn [_] (deref (.take result-q))))
+         (pool-closer shutdown? pool))))
+
+(defn upmap
+  "Like pmap, but with results returned in the order they completed.
+
+  Note that unlike core pmap, it doesn't assume the buffer size is nprocessors
+  + 2; instead, it tries to fill the pool."
+  [pool f & colls]
+  (apply upmap-manual pool (impl/get-pool-size pool) f colls))
+
+;; TODO move the following definitions to a macro? But a macro-defining-macro
+;; is a bit ugly
+
+(defn pcalls
+  "Like clojure.core.pcalls, except it takes a threadpool. For more detail on
+  its parallelism and on its threadpool argument, see pmap."
+  [pool & fs]
+  (pmap pool #(%) fs))
+
+(defn upcalls
+  "Like clojure.core.pcalls, except it takes a threadpool and returns results
+  ordered by completion time. For more detail on its parallelism and on its
+  threadpool argument, see upmap."
+  [pool & fs]
+  (upmap pool #(%) fs))
+
+(defmacro pvalues
+  "Like clojure.core.pvalues, except it takes a threadpool. For more detail on
+  its parallelism and on its threadpool argument, see pmap."
+  [pool & exprs]
+  `(pcalls ~pool ~@(for [e exprs] `(fn [] ~e))))
+
+(defmacro upvalues
+  "Like clojure.core.pvalues, except it takes a threadpool and returns results
+  ordered by completion time. For more detail on its parallelism and on its
+  threadpool argument, see upmap."
+  [pool & exprs]
+  `(upcalls ~pool ~@(for [e exprs] `(fn [] ~e))))
+
+(defmacro pfor
+  "A parallel version of for. It is like for, except it takes a threadpool and
+  is parallel. For more detail on its parallelism and on its threadpool
+  argument, see pmap.
+
+  Note that while the body is executed in parallel, the bindings are executed
+  in serial, so while this will call complex-computation in parallel:
+      (pfor pool [i (range 1000)] (complex-computation i))
+  this will not have useful parallelism:
+      (pfor pool [i (range 1000) :let [result (complex-computation i)]] result)
+
+  You can use the special binding :priority (which must be the last binding) to
+  set the priorities of the tasks.
+      (upfor (priority-threadpool 10) [i (range 1000)
+                                       :priority (inc i)]
+        (complex-computation i))
+  "
+  [pool bindings & body]
+  (impl/pfor-internal pool bindings body `pmap))
+
+(defmacro upfor
+  "Like pfor, except the return value is a sequence of results ordered by
+  *completion time*, not by input order."
+  [pool bindings & body]
+  (impl/pfor-internal pool bindings body `upmap))

--- a/src/clj/com/climate/claypoole/lazy.clj
+++ b/src/clj/com/climate/claypoole/lazy.clj
@@ -1,3 +1,16 @@
+;; The Climate Corporation licenses this file to you under under the Apache
+;; License, Version 2.0 (the "License"); you may not use this file except in
+;; compliance with the License.  You may obtain a copy of the License at
+;;
+;;   http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; See the NOTICE file distributed with this work for additional information
+;; regarding copyright ownership.  Unless required by applicable law or agreed
+;; to in writing, software distributed under the License is distributed on an
+;; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+;; or implied.  See the License for the specific language governing permissions
+;; and limitations under the License.
+
 (ns com.climate.claypoole.lazy
   (:refer-clojure :exclude [future future-call pcalls pmap pvalues])
   (:require [com.climate.claypoole :as cp]

--- a/test/com/climate/claypoole/lazy_test.clj
+++ b/test/com/climate/claypoole/lazy_test.clj
@@ -82,7 +82,7 @@
     ;; Exactly what we asked for, plus readahead, is realized.
     (is (= (+ 2 readahead) (count @started)))))
 
-(defn check-all-manual
+(defn check-all-buffer
   [fn-name manual-pmap-like ordered? streaming?]
   (check-all fn-name (fn [p f i] (manual-pmap-like p 10 f i))
              ordered? streaming?)
@@ -95,14 +95,14 @@
 (deftest test-pmap
   (check-all "pmap" lazy/pmap true true))
 
-(deftest test-pmap-manual
-  (check-all-manual "pmap-manual" lazy/pmap-manual true true))
+(deftest test-pmap-buffer
+  (check-all-buffer "pmap-buffer" lazy/pmap-buffer true true))
 
 (deftest test-upmap
   (check-all "upmap" lazy/upmap false true))
 
-(deftest test-upmap-manual
-  (check-all-manual "upmap-manual" lazy/upmap-manual false true))
+(deftest test-upmap-buffer
+  (check-all-buffer "upmap-buffer" lazy/upmap-buffer false true))
 
 (deftest test-pcalls
   (testing "basic pcalls test"
@@ -116,14 +116,14 @@
                 #(work i))))]
     (check-all "pcalls" pmap-like true true)))
 
-(deftest test-pcalls-manual
+(deftest test-pcalls-buffer
   (letfn [(pmap-like [pool buffer work input]
             (apply
-              lazy/pcalls-manual
+              lazy/pcalls-buffer
               pool buffer
               (for [i input]
                 #(work i))))]
-    (check-all-manual "pcalls-manual" pmap-like true true)))
+    (check-all-buffer "pcalls-buffer" pmap-like true true)))
 
 (deftest test-upcalls
   (testing "basic pcalls test"
@@ -137,14 +137,14 @@
                 #(work i))))]
     (check-all "upcalls" pmap-like false true)))
 
-(deftest test-upcalls-manual
+(deftest test-upcalls-buffer
   (letfn [(pmap-like [pool buffer work input]
             (apply
-              lazy/upcalls-manual
+              lazy/upcalls-buffer
               pool buffer
               (for [i input]
                 #(work i))))]
-    (check-all-manual "upcalls-manual" pmap-like false true)))
+    (check-all-buffer "upcalls-buffer" pmap-like false true)))
 
 (deftest test-pvalues
   (testing "basic pvalues test"
@@ -161,17 +161,17 @@
                  pool work)))]
     (check-all "pvalues" pmap-like true false)))
 
-(deftest test-pvalues-manual
+(deftest test-pvalues-buffer
   (letfn [(pmap-like [pool buffer work input]
             (let [worksym (gensym "work")]
               ((eval
                  `(fn [pool# buffer# ~worksym]
-                    (lazy/pvalues-manual
+                    (lazy/pvalues-buffer
                       pool# buffer#
                       ~@(for [i input]
                           (list worksym i)))))
                  pool buffer work)))]
-    (check-all-manual "pvalues-manual" pmap-like true false)))
+    (check-all-buffer "pvalues-buffer" pmap-like true false)))
 
 (deftest test-upvalues
   (testing "basic upvalues test"
@@ -188,17 +188,17 @@
                  pool work)))]
     (check-all "upvalues" pmap-like false false)))
 
-(deftest test-upvalues-manual
+(deftest test-upvalues-buffer
   (letfn [(pmap-like [pool buffer work input]
             (let [worksym (gensym "work")]
               ((eval
                  `(fn [pool# buffer# ~worksym]
-                    (lazy/upvalues-manual
+                    (lazy/upvalues-buffer
                       pool# buffer#
                       ~@(for [i input]
                           (list worksym i)))))
                  pool buffer work)))]
-    (check-all-manual "upvalues-manual" pmap-like false false)))
+    (check-all-buffer "upvalues-buffer" pmap-like false false)))
 
 (deftest test-pfor
   (testing "basic pfor test"
@@ -211,13 +211,13 @@
               (work i)))]
     (check-all "pfor" pmap-like true true)))
 
-(deftest test-pfor-manual
+(deftest test-pfor-buffer
   (letfn [(pmap-like [pool buffer work input]
-            (lazy/pfor-manual
+            (lazy/pfor-buffer
               pool buffer
               [i input]
               (work i)))]
-    (check-all-manual "pfor-manual" pmap-like true true)))
+    (check-all-buffer "pfor-buffer" pmap-like true true)))
 
 (deftest test-upfor
   (testing "basic upfor test"
@@ -230,10 +230,10 @@
               (work i)))]
     (check-all "upfor" pmap-like false true)))
 
-(deftest test-upfor-manual
+(deftest test-upfor-buffer
   (letfn [(pmap-like [pool buffer work input]
-            (lazy/upfor-manual
+            (lazy/upfor-buffer
               pool buffer
               [i input]
               (work i)))]
-    (check-all-manual "upfor-manual" pmap-like false true)))
+    (check-all-buffer "upfor-buffer" pmap-like false true)))

--- a/test/com/climate/claypoole/lazy_test.clj
+++ b/test/com/climate/claypoole/lazy_test.clj
@@ -51,7 +51,7 @@
   (cptest/check-all fn-name pmap-like ordered? streaming? true)
   (when streaming?
     (testing (format "%s is lazy in its input" fn-name)
-    (check-input-laziness pmap-like)))
+      (check-input-laziness pmap-like)))
   (testing (format "%s is lazy in its output" fn-name)
     (check-output-laziness pmap-like)))
 
@@ -87,8 +87,10 @@
   (check-all fn-name (fn [p f i] (manual-pmap-like p 10 f i))
              ordered? streaming?)
   (when streaming?
-    (check-output-controllable-readahead manual-pmap-like))
-  (check-output-controllable-readahead manual-pmap-like))
+    (testing (format "%s is lazy in its input" fn-name)
+      (check-input-controllable-readahead manual-pmap-like)))
+  (testing (format "%s is lazy in its output" fn-name)
+    (check-output-controllable-readahead manual-pmap-like)))
 
 (deftest test-pmap
   (check-all "pmap" lazy/pmap true true))

--- a/test/com/climate/claypoole/lazy_test.clj
+++ b/test/com/climate/claypoole/lazy_test.clj
@@ -1,0 +1,27 @@
+;; The Climate Corporation licenses this file to you under under the Apache
+;; License, Version 2.0 (the "License"); you may not use this file except in
+;; compliance with the License.  You may obtain a copy of the License at
+;;
+;;   http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; See the NOTICE file distributed with this work for additional information
+;; regarding copyright ownership.  Unless required by applicable law or agreed
+;; to in writing, software distributed under the License is distributed on an
+;; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+;; or implied.  See the License for the specific language governing permissions
+;; and limitations under the License.
+
+(ns com.climate.claypoole.lazy-test
+  (:require
+    [clojure.test :refer :all]
+    [com.climate.claypoole :as cp]
+    [com.climate.claypoole.lazy :as lazy]
+    [com.climate.claypoole-test :as cptest]))
+
+
+;; TODO add tests for laziness
+
+(deftest test-pmap
+  (cptest/check-all "pmap" lazy/pmap true true true)
+  (testing "pmap reads lazily"
+    (cptest/check-lazy-read lazy/pmap true)))

--- a/test/com/climate/claypoole/lazy_test.clj
+++ b/test/com/climate/claypoole/lazy_test.clj
@@ -20,6 +20,30 @@
     [com.climate.claypoole-test :as cptest]))
 
 
+(deftest test-seq-open
+  (testing "seq-open doesn't call f early"
+    (let [a (atom false)]
+      (->> (range 10)
+           (#'lazy/seq-open #(reset! a true))
+           (take 5)
+           doall)
+      (is (false? @a))))
+  (testing "seq-open calls f when s is complete"
+    (let [a (atom false)]
+      (->> (range 10)
+           (#'lazy/seq-open #(reset! a true))
+           doall)
+      (is (true? @a))))
+  (testing "seq-open calls f when there's an exception"
+    (let [a (atom false)]
+      (is (thrown? ClassCastException
+                   (->> [1 :x 2]
+                        impl/unchunk
+                        (map inc)
+                        (#'lazy/seq-open #(reset! a true))
+                        doall)))
+      (is (true? @a)))))
+
 (defn check-input-laziness
   "Check that a function is actually lazy in reading its input."
   [pmap-like]


### PR DESCRIPTION
This adds a whole suite of lazy parallel functions under com.climate.claypoole.lazy. This fixes #18.