### PR TITLE
Change pmaps to throw the original exception

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,8 @@ CHANGES
 0.4.0
 
 - Added lazy functions in com.climate.claypoole.lazy
+- Changed pmap functions to throw the original exception, not a
+  java.util.concurrent.ExecutionException
 
 0.3.3
 

--- a/src/clj/com/climate/claypoole.clj
+++ b/src/clj/com/climate/claypoole.clj
@@ -364,7 +364,7 @@
                      (when shutdown? (shutdown pool)))))]
     (deliver canceller (make-canceller driver))
     ;; Read results as available.
-    (concat (map deref
+    (concat (map impl/deref-fixing-exceptions
                  (if ordered?
                    tasks
                    (map second (impl/lazy-co-read tasks unordered-results))))

--- a/src/clj/com/climate/claypoole/lazy.clj
+++ b/src/clj/com/climate/claypoole/lazy.clj
@@ -89,7 +89,7 @@
            ;; force buffer-size futures to start work in the pool
            (forceahead (or buffer-size (impl/get-pool-size pool) 0))
            ;; read the results from the futures
-           (map deref)
+           (map impl/deref-fixing-exceptions)
            (seq-open #(when shutdown? (cp/shutdown pool)))))))
 
 (defn pmap
@@ -137,7 +137,7 @@
            ;; force buffer-size futures to start work in the pool
            (forceahead buffer-size)
            ;; read the results from the futures in the queue
-           (map (fn [_] (deref (.take result-q))))
+           (map (fn [_] (impl/deref-fixing-exceptions (.take result-q))))
            (seq-open #(if shutdown? (cp/shutdown pool)))))))
 
 (defn upmap

--- a/test/com/climate/claypoole_test.clj
+++ b/test/com/climate/claypoole_test.clj
@@ -454,11 +454,11 @@
         pool (cp/threadpool n)
         inputs [0 1 2 3 :4 5 6 7 8 9]]
     (is (thrown-with-msg?
-          ExecutionException #"keyword found"
+          NullPointerException #"keyword found"
           (dorun (pmap-like pool
                             (fn [i]
                               (if (keyword? i)
-                                (throw (Exception. "keyword found"))
+                                (throw (NullPointerException. "keyword found"))
                                 i))
                             inputs))))
     (.shutdown pool)))
@@ -471,9 +471,8 @@
         pool (cp/threadpool n)
         inputs [0 1 2 3 :4 5 6 7 8 9]]
     (is (thrown-with-msg?
-          ;; TODO throw the original exception!
-          ExecutionException #"keyword found"
-          (dorun (pmap-like pool
+          AssertionError #"keyword found"
+          (doall (pmap-like pool
                             (fn [i]
                               (if (keyword? i)
                                 (throw (AssertionError. "keyword found"))
@@ -738,7 +737,7 @@
     (is (= 2 @(cp/future :builtin (inc 1))))
     (is (= 2 @(cp/future :serial (inc 1)))))
   (letfn [(pmap-like [pool work input]
-            (map deref
+            (map impl/deref-fixing-exceptions
                  (doall
                    (for [i input]
                      (cp/future pool (work i))))))]


### PR DESCRIPTION
Pmap functions used to throw java.util.concurrent.ExecutionExceptions. This changes them to catch those and re-throw the cause. This makes try/catch work better with pmap functions.