### PR TITLE
Fix future macro to not expand to fn with invalid fn name

### DIFF
--- a/src/clj/com/climate/claypoole.clj
+++ b/src/clj/com/climate/claypoole.clj
@@ -287,7 +287,7 @@
        serial. This may be helpful during profiling, for example.
   "
   [pool & body]
-  `(future-call ~pool (^{:once true} fn future-body [] ~@body)))
+  `(future-call ~pool (^{:once true} fn ~'future-body [] ~@body)))
 
 (defn- buffer-blocking-seq
   "Make a lazy sequence that blocks when the map's (imaginary) buffer is full."


### PR DESCRIPTION
Before (note fully-qualified name of future-body):

```clojure
=> (macroexpand '(cp/future nil (println "hi")))
(com.climate.claypoole/future-call nil (clojure.core/fn com.climate.claypoole/future-body [] (println "hi")))
```
After:

```clojure
=> (macroexpand '(cp/future nil (println "hi")))
(com.climate.claypoole/future-call nil (clojure.core/fn future-body [] (println "hi")))
```