### PR TITLE
Fix typos (theadpool -> threadpool)

### DIFF
--- a/src/clj/com/climate/claypoole.clj
+++ b/src/clj/com/climate/claypoole.clj
@@ -202,7 +202,7 @@
 
   Examples:
 
-      (with-shutdown! [pool (theadpool 6)]
+      (with-shutdown! [pool (threadpool 6)]
         (doall (pmap pool identity (range 1000))))
       (with-shutdown! [pool1 6
                        pool2 :serial]

--- a/src/clj/com/climate/claypoole/impl.clj
+++ b/src/clj/com/climate/claypoole/impl.clj
@@ -99,7 +99,7 @@
                 (instance? ExecutorService pool))
     (throw (IllegalArgumentException.
              (format
-               (str "Theadpool futures require a threadpool, :builtin, or "
+               (str "Threadpool futures require a threadpool, :builtin, or "
                     ":serial, not %s.") pool)))))
 
 (defonce ^{:doc "The previously-used threadpool ID."}


### PR DESCRIPTION
Came across `Theadpool` in an exception. Found another one in doc-string :)