### PR TITLE
implement support for completable futures for non-blocking io

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -1,0 +1,21 @@
+name: Clojure CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: '1.8' # The JDK version to make available on the path.
+        java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
+        architecture: x64 # (x64 or x86) - defaults to x64
+    - uses: DeLaGuardo/setup-clojure@2.0
+      with:
+        tools-deps: '1.10.1.469'
+    - name: Install dependencies
+      run: sudo apt-get update; sudo apt-get install rlwrap 
+    - name: Run tests
+      run: lein test

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -15,7 +15,5 @@ jobs:
     - uses: DeLaGuardo/setup-clojure@2.0
       with:
         tools-deps: '1.10.1.469'
-    - name: Install dependencies
-      run: sudo apt-get update; sudo apt-get install rlwrap 
     - name: Run tests
       run: lein test

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ start work going and know it'll get done. But if you try to `pmap` over
 (def pool (cp/threadpool 2))
 ;; Future
 (def fut (cp/future pool (myfn myinput)))
+;; Completable Future
+(def cfut (cp/completable-future pool (myfn myinput)))
 ;; Ordered pmap
 (def intermediates (cp/pmap pool myfn1 myinput-a myinput-b))
 ;; We can feed the streaming sequence right into another parallel function.

--- a/test/com/climate/claypoole_test.clj
+++ b/test/com/climate/claypoole_test.clj
@@ -965,6 +965,6 @@
                              (range 10)))]
         (Thread/sleep 100)
         ;; As requested, only 3 items have been started
-        (is (= @started (range 3)))
+        (is (= (set @started) (set (range 3))))
         (deliver start true)
         (dorun tasks)))))

--- a/test/com/climate/claypoole_test.clj
+++ b/test/com/climate/claypoole_test.clj
@@ -933,11 +933,11 @@
       ;; Ok, tell those threads to go.
       (deliver blocker true)
       (is @complete)
-      (is (= (range 10) (sort @processed))))))
+      (is (= (range 10) (sort @processed)))))
   ;; We don't run the whole battery of tests because (1) it's hard to make a
   ;; pmap-like function out of pdoseq, and (2) pdoseq is just (comp dorun
   ;; upmap).
-  
+  )
 
 (deftest test-pdoseq
   (test-parallel-do


### PR DESCRIPTION
I would like to add built-in support for using completable futures with claypoole, this is a simple implementation which adds two new things:
- completable-future-call: just like `future-call` but returns a `CompletableFuture`
- completable-future: macro like `future` but returns a `CompletableFuture`