### PR TITLE
add missing bindings support for completable future via binding-conveyor-fn

### DIFF
--- a/src/clj/com/climate/claypoole.clj
+++ b/src/clj/com/climate/claypoole.clj
@@ -310,10 +310,11 @@
    ;; If requested, use the default threadpool.
    (= :builtin pool) (completable-future-call clojure.lang.Agent/soloExecutor f)
    :else
-   (CompletableFuture/supplyAsync
-    (reify Supplier
-      (get [_]
-        (f))) pool)))
+   (let [f* (impl/binding-conveyor-fn f)]
+     (CompletableFuture/supplyAsync
+      (reify Supplier
+        (get [_]
+          (f*))) pool))))
 
 (defmacro completable-future
   "Like clojure.core/future, but using a threadpool and returns a CompletableFuture.

--- a/test/com/climate/claypoole_test.clj
+++ b/test/com/climate/claypoole_test.clj
@@ -25,6 +25,7 @@
      ExecutorService
      LinkedBlockingQueue]))
 
+(def ^:dynamic *test-context* nil)
 
 (defn callable
   "Just a cast."
@@ -785,6 +786,14 @@
                 (range 10))]
         (is (= @f (range 10)))
         (is (true? @a)))))
+  (testing "bindings completable-future test"
+    (cp/with-shutdown! [pool 3]
+      (binding [*test-context* ::bound-value]
+        (let [f (cp/completable-future
+                  pool
+                  ;; Body can contain multiple elements.
+                  *test-context*)]
+          (is (= @f ::bound-value))))))
   (testing "completable-future threadpool args"
     (is (thrown? IllegalArgumentException (cp/completable-future 3 (inc 1))))
     (is (thrown? IllegalArgumentException (cp/completable-future nil (inc 1))))


### PR DESCRIPTION
- when I added `completable-future` recently I forgot to add support for dynamic bindings via `binding-conveyor-fn`.
- i've added binding-conveyor-fn support in this PR as well as added a test to verify it works.