### PR TITLE
Add clj-kondo.exports

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:paths ["src/clj" "target/classes"]
+{:paths ["resources" "src/clj" "target/classes"]
  :deps {}
  :deps/prep-lib {:alias :build
                  :fn compile

--- a/project.clj
+++ b/project.clj
@@ -25,6 +25,7 @@
 
   :min-lein-version "2.0.0"
   :source-paths ["src/clj"]
+  :resource-paths ["resources"]
   :java-source-paths ["src/java"]
   :pedantic? :warn
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.3"]]}

--- a/resources/clj-kondo.exports/clj-kondo/claypoole/clj_kondo/claypoole.clj
+++ b/resources/clj-kondo.exports/clj-kondo/claypoole/clj_kondo/claypoole.clj
@@ -1,0 +1,41 @@
+(ns clj-kondo.claypoole
+  (:refer-clojure :exclude [future pmap pvalues])
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn pool-and-body
+  [token]
+  (fn [{:keys [:node]}]
+    (let [[pool & body] (rest (:children node))
+          new-node (api/list-node
+                    (list*
+                     (api/token-node token)
+                     (api/list-node
+                      (list* (api/token-node 'do)
+                             pool
+                             body))))]
+      {:node (with-meta new-node
+               (meta node))})))
+
+(defn pool-with-binding-vec-or-exprs-and-body
+  [token]
+  (fn [{:keys [:node]}]
+    (let [[pool binding-vec-or-exprs & body] (rest (:children node))
+          new-node (api/list-node
+                    [(api/token-node token)
+                     binding-vec-or-exprs
+                     (api/list-node
+                      (list* (api/token-node 'do)
+                             pool
+                             body))])]
+      {:node (with-meta new-node
+               (meta node))})))
+
+(def future (pool-and-body 'future))
+(def completable-future (pool-and-body 'future))
+(def pdoseq (pool-with-binding-vec-or-exprs-and-body 'doseq))
+(def pmap (pool-and-body 'map))
+(def upmap (pool-and-body 'map))
+(def pvalues (pool-and-body 'pvalues))
+(def upvalues (pool-and-body 'pvalues))
+(def pfor (pool-with-binding-vec-or-exprs-and-body 'for))
+(def upfor (pool-with-binding-vec-or-exprs-and-body 'for))

--- a/resources/clj-kondo.exports/clj-kondo/claypoole/config.edn
+++ b/resources/clj-kondo.exports/clj-kondo/claypoole/config.edn
@@ -1,0 +1,18 @@
+{:linters {:claypoole {:level :warning}}
+ :lint-as {com.climate.claypoole/with-shutdown! clojure.core/let}
+ :hooks   {:analyze-call {com.climate.claypoole/future             clj-kondo.claypoole/future
+                          com.climate.claypoole/completable-future clj-kondo.claypoole/completable-future
+                          com.climate.claypoole/pdoseq             clj-kondo.claypoole/pdoseq
+                          com.climate.claypoole/pmap               clj-kondo.claypoole/pmap
+                          com.climate.claypoole/upmap              clj-kondo.claypoole/upmap
+                          com.climate.claypoole/pvalues            clj-kondo.claypoole/pvalues
+                          com.climate.claypoole/upvalues           clj-kondo.claypoole/upvalues
+                          com.climate.claypoole/pfor               clj-kondo.claypoole/pfor
+                          com.climate.claypoole/upfor              clj-kondo.claypoole/upfor
+                          com.climate.claypoole.lazy/pdoseq        clj-kondo.claypoole/pdoseq
+                          com.climate.claypoole.lazy/pmap          clj-kondo.claypoole/pmap
+                          com.climate.claypoole.lazy/upmap         clj-kondo.claypoole/upmap
+                          com.climate.claypoole.lazy/pvalues       clj-kondo.claypoole/pvalues
+                          com.climate.claypoole.lazy/upvalues      clj-kondo.claypoole/upvalues
+                          com.climate.claypoole.lazy/pfor          clj-kondo.claypoole/pfor
+                          com.climate.claypoole.lazy/upfor         clj-kondo.claypoole/upfor}}}


### PR DESCRIPTION
Same changes as https://github.com/clj-commons/claypoole/pull/66/files, but corrects the doubly nested `resources` directory